### PR TITLE
Added a filter to exclude specific folder names from the checks.

### DIFF
--- a/theme-mentor.php
+++ b/theme-mentor.php
@@ -227,6 +227,13 @@ class Mentor_Themeforest {
 		$folder		 = trailingslashit( $folder );
 		$directory	 = dir( $folder );
 
+		/* A list of folders excluded from the check. */
+		$excluded_folders = apply_filters( 'theme_mentory_excluded_folders', array() );
+
+		if ( in_array( basename( $folder ), $excluded_folders ) ) {
+			return;
+		}
+
 		while ( false !== ( $entry = $directory->read() ) ) {
 			// drop all empty folders, hidden folders/files and parents
 			if ( ( $entry[ 0 ] == "." ) )


### PR DESCRIPTION
As the subjects says, I've added a filter to exclude specific folder names from the checks.

This is particularly useful for those of us who develop themes using Grunt, or Gulp, or generally that rely on Node components that create very large folders such as `node_modules`, that are not part of the theme itself, but add significant overhead to the theme check process.